### PR TITLE
add: Input, FormGroup 컴포넌트 생성, Emotion ThemeProvider, GlobalCSS 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/react-dom": "18.0.11",
     "antd": "^5.3.2",
     "axios": "^1.3.4",
+    "classnames": "^2.3.2",
     "emotion-reset": "^3.0.1",
     "eslint": "8.36.0",
     "eslint-config-next": "13.2.4",

--- a/src/components/formGroup/index.tsx
+++ b/src/components/formGroup/index.tsx
@@ -1,0 +1,18 @@
+import React, { FunctionComponent } from 'react';
+import Input from '@components/input';
+
+const FormGroup: FunctionComponent = () => {
+  return (
+    <form>
+      <Input label="이름" id="name" className="mb-4" autoFocus maxLength={20} />
+      <Input
+        label="휴대폰 번호"
+        id="phoneNumber"
+        className="mb-4"
+        maxLength={13}
+      />
+    </form>
+  );
+};
+
+export default FormGroup;

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -1,0 +1,77 @@
+import React, { InputHTMLAttributes } from 'react';
+import styled from '@emotion/styled';
+import classNames from 'classnames';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  className?: string;
+  label?: string;
+  message?: string;
+}
+
+const Input: React.ForwardRefExoticComponent<InputProps> = React.forwardRef<
+  HTMLInputElement,
+  InputProps
+>((props, ref) => {
+  const { className, label, message, id } = props;
+
+  return (
+    <div className={classNames('flex h-14 items-center', className)}>
+      {label && (
+        <LabelWrapper>
+          <label htmlFor={id}>{label}</label>
+        </LabelWrapper>
+      )}
+      <div className="relative flex w-full">
+        <InputElement id={id} ref={ref} {...props} autoComplete="off" />
+        {message && (
+          <ErrorMessage role="alert">{message as string}</ErrorMessage>
+        )}
+      </div>
+    </div>
+  );
+});
+
+Input.displayName = 'Input';
+
+export default Input;
+
+const LabelWrapper = styled.div`
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  width: 20%;
+  min-width: 64px;
+  padding: 0 12px;
+  font-size: 14px;
+`;
+
+const InputElement = styled.input`
+  width: 100%;
+  height: 38px;
+  padding: 6px 12px;
+  margin: 0;
+  background: ${({ theme }) => theme.colors.white};
+  border: 1px solid ${({ theme }) => theme.colors.gray};
+  border-radius: 6px;
+  color: ${({ theme }) => theme.colors.black};
+  outline: none;
+  box-sizing: border-box;
+  &:focus {
+    border-color: ${({ theme }) => theme.colors.secondary};
+    box-shadow: 0 0 0 0.25rem rgb(44 62 118 / 25%);
+  }
+  &::placeholder {
+    color: ${({ theme }) => theme.colors['secondary-gray']};
+  }
+  &:disabled {
+    background-color: ${({ theme }) => theme.colors.disabled};
+  }
+`;
+
+const ErrorMessage = styled.small`
+  position: absolute;
+  bottom: -20px;
+  color: ${({ theme }) => theme.colors.red};
+  font-size: 12px;
+`;

--- a/src/components/layout/base/index.tsx
+++ b/src/components/layout/base/index.tsx
@@ -1,13 +1,18 @@
 import { FunctionComponent, PropsWithChildren } from 'react';
+import styled from '@emotion/styled';
 import Header from '../header';
 
 const BaseLayout: FunctionComponent<PropsWithChildren> = ({ children }) => {
   return (
     <>
       <Header />
-      <main className="flex items-center justify-center">{children}</main>
+      <MainWrapper>{children}</MainWrapper>
     </>
   );
 };
 
 export default BaseLayout;
+
+const MainWrapper = styled.main`
+  padding: 1rem;
+`;

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,0 +1,11 @@
+import { css } from '@emotion/react';
+
+const global = css`
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+`;
+
+export default global;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,18 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
+import { Global, ThemeProvider } from '@emotion/react';
+import theme from 'theme';
+import global from 'global';
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
   require('../mocks');
 }
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <ThemeProvider theme={theme}>
+      <Global styles={global} />
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,7 @@
 import { useEffect } from 'react';
 import axios from 'axios';
-import tw from 'twin.macro';
-import styled from '@emotion/styled';
-import { Button } from 'antd';
 import { BaseLayout } from '@components/layout';
+import FormGroup from '@components/formGroup';
 
 export default function Home() {
   const fetchData = async () => {
@@ -27,23 +25,9 @@ export default function Home() {
 
   return (
     <BaseLayout>
-      <main className="flex flex-col border border-red-500 bg-light">
-        헬로월드
-        <Input placeholder="box" />
-        <MyDiv>Test Text</MyDiv>
-        <Button type="primary">Button</Button>
-      </main>
+      <div className="flex flex-col space-y-12">
+        <FormGroup />
+      </div>
     </BaseLayout>
   );
 }
-
-const height = '72px';
-
-const Input = tw.input`
-    text-center border h-[${height}] bg-gray-200
-`;
-const MyDiv = styled.div`
-  background: gold;
-  font-size: 2rem;
-  margin-top: 10px;
-`;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,37 @@
+import { Theme } from '@emotion/react';
+
+const color = {
+  black: '#212529',
+  dark: '#191a20',
+  stone: '#444444',
+  'light-dark': '#E8F0FE',
+  primary: '#2C3E76',
+  secondary: '#969fbb',
+  white: '#ffffff',
+  light: '#f5f5f5',
+  gray: '#ced4da',
+  'secondary-gray': '#b6b6b6',
+  disabled: '#e9ecef',
+  red: '#ff0000',
+  blue: '#1180ff',
+};
+
+const theme: Theme = {
+  colors: {
+    black: color.black,
+    dark: color.dark,
+    stone: color.stone,
+    'light-dark': color['light-dark'],
+    primary: color.primary,
+    secondary: color.secondary,
+    white: color.white,
+    light: color.light,
+    gray: color.gray,
+    'secondary-gray': color['secondary-gray'],
+    disabled: color.disabled,
+    red: color.red,
+    blue: color.blue,
+  },
+};
+
+export default theme;

--- a/src/types/emotion.d.ts
+++ b/src/types/emotion.d.ts
@@ -1,0 +1,21 @@
+import '@emotion/react';
+
+declare module '@emotion/react' {
+  export interface Theme {
+    colors: {
+      black: string;
+      dark: string;
+      stone: string;
+      'light-dark': string;
+      primary: string;
+      secondary: string;
+      white: string;
+      light: string;
+      gray: string;
+      'secondary-gray': string;
+      disabled: string;
+      red: string;
+      blue: string;
+    };
+  }
+}


### PR DESCRIPTION
- 공통 Input 컴포넌트 생성, FormGroup 컴포넌트 생성
- Emotion ThemeProvider 적용 (props 로 theme.colors 를 전달받기 쉽게)

<img width="696" alt="스크린샷 2023-03-26 오후 2 01 17" src="https://user-images.githubusercontent.com/69143207/227756295-f5dbf3c3-a19c-4f44-a87b-978e0c4dfe3c.png">
