### PR TITLE
fix: Form 제출 버튼 더블 클릭 방지 적용, 제출 뒤 확인 모달 열림 및 초기화

### DIFF
--- a/src/components/formGroup/index.tsx
+++ b/src/components/formGroup/index.tsx
@@ -36,6 +36,8 @@ const FormGroup: FunctionComponent = () => {
     name: 'loadPlace',
   });
 
+  const [isDisabledSubmitBtn, setIsDisabledSubmitBtn] =
+    useState<boolean>(false);
   const [responseModalOpen, setResponseModalOpen] = useState<boolean>(false);
   const [responseMessage, setResponseMessage] = useState<string>('');
   const [openPostcode, setOpenPostcode] = useState<boolean>(false);
@@ -56,7 +58,7 @@ const FormGroup: FunctionComponent = () => {
     reset(DEFAULT_VALUES);
   };
 
-  const onSubmit = (data: FieldValues) => {
+  const onSubmit = async (data: FieldValues) => {
     const {
       name,
       phoneNumber,
@@ -100,11 +102,20 @@ const FormGroup: FunctionComponent = () => {
 
     console.log('body', body);
     mutate(body);
+
+    await new Promise((r) => setTimeout(r, 1000));
+    remove([1, 2]);
+    setIsDisabledSubmitBtn(false);
   };
 
   const handleOpenPostcodeModal = (addressId: string) => {
     setAddressInputId(addressId);
     setOpenPostcode(true);
+  };
+
+  const handleCloseResponseModal = () => {
+    setResponseModalOpen(false);
+    setResponseMessage('');
   };
 
   const handleSelectAddress = (address: { roadAddress: string }) => {
@@ -122,10 +133,12 @@ const FormGroup: FunctionComponent = () => {
     <>
       <form
         onSubmit={handleSubmit(async (data) => {
+          setIsDisabledSubmitBtn(true);
           await new Promise((r) => setTimeout(r, 1000));
           try {
             onSubmit(data);
           } catch (error) {
+            setIsDisabledSubmitBtn(false);
             console.log(error);
           }
         })}
@@ -305,7 +318,11 @@ const FormGroup: FunctionComponent = () => {
           </div>
         </div>
         <div className="addButton mt-1.5">
-          <Button text="등록" className="" />
+          <Button
+            text="등록"
+            className=""
+            disabled={isSubmitting || isDisabledSubmitBtn}
+          />
         </div>
       </form>
       {openPostcode && (
@@ -318,6 +335,14 @@ const FormGroup: FunctionComponent = () => {
               padding: '24px',
             }}
           />
+        </Modal>
+      )}
+      {responseModalOpen && responseMessage && (
+        <Modal title="요청 성공" onClose={handleCloseResponseModal}>
+          <div className="flex flex-col space-y-4 px-4 py-6">
+            <h3 className="text-lg font-semibold">등록이 완료 되었습니다.</h3>
+            <div>{responseMessage}</div>
+          </div>
         </Modal>
       )}
     </>


### PR DESCRIPTION
- formState 의 isSubmitting(boolean) 값 사용
- POST 요청 시 별도의 상태 isDisabledSubmitBtn(boolean) 값 상태 변경
- 제출 버튼의 disabled={isSubmitting || isDisabledSubmitBtn} 설정으로 복수의 클릭 요청 방지 적용
- 상차지 정보 박스는 index 가 0 인 항목만 남도록 수정 (remove[1, 2])
- 제출 버튼 클릭 시 요청 응답 데이터 (저장한 항목) 를 모달에 문자열로 보여주도록 적용

<img width="1918" alt="스크린샷 2023-03-27 오전 12 24 59" src="https://user-images.githubusercontent.com/69143207/227785963-b3d47254-bf4f-43f6-8717-2cf4c58b45d7.png">
