### PR TITLE
add: OrderTable 컴포넌트 생성 및 데이터 연동 (GET 조회 시 page, size)

### DIFF
--- a/src/components/formGroup/index.tsx
+++ b/src/components/formGroup/index.tsx
@@ -9,16 +9,20 @@ import Modal from '@components/modal';
 import RangePicker from '@components/rangePicker';
 import SelectInput from '@components/selectInput';
 import DatePickerField from '@components/datePicker';
+import { useAddOrderMutation } from 'hooks/api/orders';
 import {
   ITEM_SELECTION,
   SUPPLY_SELECTION,
   DEFAULT_VALUES,
 } from 'constant/form';
-import { LoadPlaceFields } from 'types/form';
+import { LoadPlaceFields, PageType } from 'types/form';
 import { cls } from 'utils';
-import { useAddOrderMutation } from 'hooks/api/orders';
 
-const FormGroup: FunctionComponent = () => {
+interface Props {
+  setSearchInfo: React.Dispatch<React.SetStateAction<PageType>>;
+}
+
+const FormGroup: FunctionComponent<Props> = ({ setSearchInfo }) => {
   const methods = useFormContext();
   const {
     register,
@@ -100,9 +104,10 @@ const FormGroup: FunctionComponent = () => {
       loadPlace: loadingPlaceConversion,
     };
 
-    console.log('body', body);
     mutate(body);
-
+    setSearchInfo((prevState) => {
+      return { ...prevState, page: 1 };
+    });
     await new Promise((r) => setTimeout(r, 1000));
     remove([1, 2]);
     setIsDisabledSubmitBtn(false);

--- a/src/components/orderTable/index.tsx
+++ b/src/components/orderTable/index.tsx
@@ -1,0 +1,255 @@
+import React, { FunctionComponent, useState } from 'react';
+import { Table as AntdTable } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { useFormContext } from 'react-hook-form';
+import styled from '@emotion/styled';
+import Button from 'components/button';
+import Modal from 'components/modal';
+import { ResponseType, OrderFields as DataType, PageType } from 'types/form';
+
+interface TableProps {
+  isLoading: boolean;
+  selectedRowKeys: number[];
+  tableData: ResponseType | undefined;
+  searchInfo: PageType;
+  setSelectedRowKeys: React.Dispatch<React.SetStateAction<number[]>>;
+  setSearchInfo: React.Dispatch<React.SetStateAction<PageType>>;
+}
+
+const ReceicivingCompleteTable: FunctionComponent<TableProps> = ({
+  isLoading,
+  tableData,
+  selectedRowKeys,
+  searchInfo,
+  setSelectedRowKeys,
+  setSearchInfo,
+}: TableProps) => {
+  const [isDisabledDeleteBtn, setIsDisabledDeleteBtn] =
+    useState<boolean>(false);
+  const [responseModalOpen, setResponseModalOpen] = useState<boolean>(false);
+  const [responseMessage, setResponseMessage] = useState<string>('');
+
+  const methods = useFormContext();
+  const { reset } = methods;
+
+  const handleCloseResponseModal = () => {
+    setResponseModalOpen(false);
+    setResponseMessage('');
+  };
+
+  const handleDeleteOrder = () => {
+    console.log('selectedRowKeys', selectedRowKeys);
+  };
+
+  const handlePage = async (page: number) => {
+    setSelectedRowKeys([]);
+    setSearchInfo((prevState) => {
+      return { ...prevState, page };
+    });
+  };
+
+  const onSelectChange = (record: any) => {
+    setSelectedRowKeys(record);
+  };
+
+  const rowSelection = {
+    selectedRowKeys,
+    onChange: onSelectChange,
+  };
+
+  const columns: ColumnsType<DataType> = [
+    {
+      title: '이름',
+      dataIndex: 'name',
+      key: 'name',
+      fixed: 'left',
+      render: (text: string) => {
+        return text || '-';
+      },
+    },
+    {
+      title: '휴대폰번호',
+      dataIndex: 'phoneNumber',
+      key: 'phoneNumber',
+      fixed: 'left',
+      render: (text: string) => {
+        return text || '-';
+      },
+    },
+    {
+      title: '날짜',
+      dataIndex: 'date',
+      key: 'date',
+      fixed: 'left',
+      render: (_: string, record: DataType) => {
+        const { fromDate, toDate } = record;
+        return `${fromDate} ~ ${toDate}`;
+      },
+    },
+    {
+      title: '품목',
+      dataIndex: 'item',
+      key: 'item',
+      render: (_: string, record: DataType) => {
+        const { item, itemDetail } = record;
+        return item !== '직접입력' ? item || '-' : itemDetail || '-';
+      },
+    },
+    {
+      title: '단위',
+      dataIndex: 'supply',
+      key: 'supply',
+      render: (text: string) => {
+        return text || '-';
+      },
+    },
+    {
+      title: '물량',
+      dataIndex: 'supplyDetail',
+      key: 'supplyDetail',
+      render: (text: string) => {
+        return text || '-';
+      },
+    },
+    {
+      title: '출근지',
+      dataIndex: 'address',
+      key: 'address',
+      render: (text: string) => {
+        return text || '-';
+      },
+    },
+    {
+      title: '오더복사',
+      dataIndex: 'copyOrder',
+      key: 'copyOrder',
+      fixed: 'right',
+      render: (_: string, record: DataType) => {
+        return (
+          <span
+            className="cursor-pointer underline hover:text-blue-500"
+            onClick={() => {
+              reset(record);
+            }}
+          >
+            오더복사
+          </span>
+        );
+      },
+    },
+  ];
+
+  return (
+    <>
+      <TableWrapper>
+        <Button
+          type="button"
+          text="삭제"
+          className="absolute right-0 -top-11 z-10"
+          handleClick={handleDeleteOrder}
+          disabled={isDisabledDeleteBtn}
+        />
+        <AntdTable
+          loading={isLoading}
+          rowKey="seqNo"
+          columns={columns}
+          dataSource={tableData?.orders}
+          tableLayout="fixed"
+          bordered={false}
+          size="small"
+          pagination={{
+            onChange: handlePage,
+            position: ['bottomCenter'],
+            defaultCurrent: 1,
+            current: searchInfo.page,
+            pageSize: searchInfo.size,
+            total: tableData?.total || 0,
+            defaultPageSize: 20,
+            pageSizeOptions: [20, 50, 100],
+            onShowSizeChange: (_, size) => {
+              setSelectedRowKeys([]);
+              setSearchInfo((prevState) => {
+                return { ...prevState, page: 1, size };
+              });
+            },
+          }}
+          scroll={{ x: 768, y: 500 }}
+          rowSelection={rowSelection}
+        />
+      </TableWrapper>
+      {responseModalOpen && responseMessage && (
+        <Modal title="요청 성공" onClose={handleCloseResponseModal}>
+          <div className="flex flex-col space-y-4 px-4 py-6">
+            <h3 className="text-lg font-semibold">삭제가 완료 되었습니다.</h3>
+            <p className="h-30 w-72 break-all line-clamp-3">
+              {responseMessage}
+            </p>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+};
+
+export default ReceicivingCompleteTable;
+
+const TableWrapper = styled.div`
+  position: relative;
+  -webkit-box-shadow: 0px 0px 6px 0px rgb(0 0 0 / 10%);
+  box-shadow: 0px 0px 6px 0px rgb(0 0 0 / 10%);
+
+  .ant-table-tbody {
+    cursor: pointer;
+  }
+
+  .ant-table-thead {
+    font-size: 0.75rem;
+
+    .ant-table-cell {
+      text-align: center;
+      font-weight: bold;
+      background: ${({ theme }) => theme.colors.disabled};
+      border-bottom: 1px solid ${({ theme }) => theme.colors['secondary-gray']};
+    }
+
+    .ant-table-cell::before {
+      all: unset;
+    }
+  }
+
+  .ant-table-tbody {
+    font-size: 0.75rem;
+  }
+
+  .ant-table-cell {
+    text-align: center;
+    padding: 4px !important;
+  }
+
+  .ant-table-thead > tr > th {
+    height: 38px;
+    color: rgba(0, 0, 0, 0.85);
+    background: #fafafa;
+    transition: background 0.3s ease;
+  }
+
+  .ant-table-tbody > tr > td {
+    transition: background 0.3s;
+  }
+
+  .ant-table-tbody > tr.ant-table-row-selected > td {
+    background: #e6f7ff;
+    border-color: #abd4fc;
+  }
+
+  ul.ant-pagination {
+    .ant-pagination-prev,
+    .ant-pagination-next {
+      .ant-pagination-item-link {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+    }
+  }
+`;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -22,7 +22,8 @@ export default function App({ Component, pageProps }: AppProps) {
       new QueryClient({
         defaultOptions: {
           queries: {
-            staleTime: Infinity,
+            staleTime: 10 * (60 * 1000),
+            cacheTime: 15 * (60 * 1000),
           },
         },
       })

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,26 +1,43 @@
+import { useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { BaseLayout } from '@components/layout';
 import FormGroup from '@components/formGroup';
+import OrderTable from '@components/orderTable';
 import { useOrders } from 'hooks/api/orders';
-import { FormFields } from 'types/form';
+import { FormFields, PageType } from 'types/form';
 import { DEFAULT_VALUES } from 'constant/form';
 
 export default function Home() {
+  const [selectedRowKeys, setSelectedRowKeys] = useState<number[]>([]);
+
+  const [searchInfo, setSearchInfo] = useState<PageType>({
+    page: 1,
+    size: 20,
+  });
+
   const methods = useForm<FormFields>({
     mode: 'all',
     defaultValues: DEFAULT_VALUES,
   });
 
   const { data: orderlist, isFetching } = useOrders({
-    page: 1,
-    size: 10,
+    page: searchInfo.page,
+    size: searchInfo.size,
   });
 
   return (
     <BaseLayout>
       <FormProvider {...methods}>
         <div className="flex flex-col space-y-12">
-          <FormGroup />
+          <FormGroup setSearchInfo={setSearchInfo} />
+          <OrderTable
+            isLoading={isFetching}
+            selectedRowKeys={selectedRowKeys}
+            searchInfo={searchInfo}
+            tableData={!isFetching ? orderlist : undefined}
+            setSearchInfo={setSearchInfo}
+            setSelectedRowKeys={setSelectedRowKeys}
+          />
         </div>
       </FormProvider>
     </BaseLayout>


### PR DESCRIPTION
- OrderTable 컴포넌트 생성 (AntdTable) 및 데이터 연동
- page, pageSize 를 선택 시 상태값 page, size 변경 및 refetch (setSearchInfo)
- 테이블의 개별 항목에 대한 오더복사 기능 추가 (reset(record))
- staleTime, cacheTime 적용. 요청한 페이지는 다시 서버에 요청하지 않음
<img width="1395" alt="스크린샷 2023-03-27 오전 9 07 06" src="https://user-images.githubusercontent.com/69143207/227813505-4d46b805-1e67-4d54-9acd-b9b8e2929d20.png">
