### PR TITLE
add: 주문 항목 삭제(DELETE) mock API 훅 구현 및 적용

### DIFF
--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -17,3 +17,13 @@ export const addOrder = async (body: ReqBody) => {
 
   return data;
 };
+
+export const deleteOrder = async (ids: number[]) => {
+  const { data } = await axios.delete('/order', {
+    data: {
+      ids,
+    },
+  });
+
+  return data;
+};

--- a/src/components/orderTable/index.tsx
+++ b/src/components/orderTable/index.tsx
@@ -3,8 +3,9 @@ import { Table as AntdTable } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { useFormContext } from 'react-hook-form';
 import styled from '@emotion/styled';
-import Button from 'components/button';
-import Modal from 'components/modal';
+import Button from '@components/button';
+import Modal from '@components/modal';
+import { useDeleteOrderMutation } from 'hooks/api/orders';
 import { ResponseType, OrderFields as DataType, PageType } from 'types/form';
 
 interface TableProps {
@@ -32,13 +33,29 @@ const ReceicivingCompleteTable: FunctionComponent<TableProps> = ({
   const methods = useFormContext();
   const { reset } = methods;
 
+  const { mutate } = useDeleteOrderMutation((response) => {
+    if (response.success) {
+      setSelectedRowKeys([]);
+      const { orderIds } = response;
+      setResponseModalOpen(true);
+      setResponseMessage(JSON.stringify(orderIds));
+      setIsDisabledDeleteBtn(false);
+    }
+  });
+
   const handleCloseResponseModal = () => {
     setResponseModalOpen(false);
     setResponseMessage('');
   };
 
-  const handleDeleteOrder = () => {
-    console.log('selectedRowKeys', selectedRowKeys);
+  const handleDeleteOrder = async () => {
+    if (!selectedRowKeys || selectedRowKeys.length === 0) {
+      alert('선택된 테이블 행이 없습니다.');
+      return null;
+    }
+
+    setIsDisabledDeleteBtn(true);
+    mutate(selectedRowKeys);
   };
 
   const handlePage = async (page: number) => {

--- a/src/hooks/api/orders.ts
+++ b/src/hooks/api/orders.ts
@@ -28,3 +28,20 @@ export const useAddOrderMutation = (
     },
   });
 };
+
+export const useDeleteOrderMutation = (
+  successCallback: (result: {
+    success: boolean;
+    message: string;
+    orderIds: number[];
+  }) => void
+) => {
+  const client = useQueryClient();
+  return useMutation((ids: number[]) => api.deleteOrder(ids), {
+    onSuccess: (result) => {
+      client
+        .invalidateQueries(['orderlist'])
+        .then(() => successCallback(result));
+    },
+  });
+};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -60,6 +60,42 @@ export const handlers = [
       console.log(error);
     }
   }),
+  rest.delete('/order', async (req, res, ctx) => {
+    const data = await req.json();
+
+    const { ids: orderIds } = data;
+
+    if (!orderIds || orderIds.length < 1) {
+      return res(
+        ctx.status(404),
+        ctx.json({
+          success: false,
+          message: '주문 id를 찾을 수 없습니다.',
+          orderIds: [],
+        })
+      );
+    }
+
+    const targetIds = orders
+      .filter((order) => orderIds.includes(order.seqNo))
+      .map((order) => order.seqNo);
+
+    targetIds.forEach((targetId) => {
+      const targetIndex = orders.findIndex((order) => order.seqNo === targetId);
+      orders.splice(targetIndex, 1);
+    });
+
+    await sleep(200);
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        success: true,
+        message: '삭제가 완료 되었습니다.',
+        orderIds,
+      })
+    );
+  }),
 ];
 
 async function sleep(timeout: number) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -22,8 +22,7 @@ export default function App({ Component, pageProps }: AppProps) {
       new QueryClient({
         defaultOptions: {
           queries: {
-            staleTime: 10 * (60 * 1000),
-            cacheTime: 15 * (60 * 1000),
+            staleTime: Infinity,
           },
         },
       })

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { BaseLayout } from '@components/layout';
 import FormGroup from '@components/formGroup';
@@ -24,6 +24,15 @@ export default function Home() {
     page: searchInfo.page,
     size: searchInfo.size,
   });
+
+  useEffect(() => {
+    if (orderlist && !orderlist['total']) {
+      setSearchInfo({
+        page: 1,
+        size: 20,
+      });
+    }
+  }, [orderlist]);
 
   return (
     <BaseLayout>


### PR DESCRIPTION
- 테이블의 항목 주문 건들 선택 시 삭제 되도록 요청하는 API 작성 및 기능 연동작업
- 삭제 버튼의 더블클릭 방지 적용
- 테이블 내 데이터를 모두 삭제했을 때 page, size 값 초기화 (useEffect)
<img width="1186" alt="스크린샷 2023-03-27 오후 12 49 24" src="https://user-images.githubusercontent.com/69143207/227836426-eb434b04-a896-4eda-b9be-d41a3abb9c5d.png">
